### PR TITLE
fix(#2): remove split from command

### DIFF
--- a/panels/_utils/utils.py
+++ b/panels/_utils/utils.py
@@ -138,12 +138,9 @@ def is_ffmpeg_compatible(file_url) -> bool:
     Checks to see if the file (local and non-local) is compatible with ffmpeg.
     :returns: success
     """
-    # command = f"{FFMPEG} -y -v error -i {file_url} {os.path.join(WIN_TMP, 'verify-ffmpeg.png')}"
-    # err = subprocess.run(command.split(" "), capture_output=True).stderr
-    # return err == b''
-
-    # ABOVE BROKEN DOESN"T WORK
-    return True
+    command = f"{FFMPEG} -y -v error -i {file_url} {os.path.join(WIN_TMP, 'verify-ffmpeg.png')}"
+    err = subprocess.run(command, capture_output=True).stderr
+    return err == b''
 
 
 def find_gif_duration(img_obj) -> float:


### PR DESCRIPTION
this fixed the issue stated in #2 locally for me, the only key differences between the environments is that i am running ffmpeg v6.1.1, this shouldnt affect this (hopefully), but the command was no longer throwing a file error when I ran it with the fix